### PR TITLE
Insert token in a correct position in a  buffer

### DIFF
--- a/autoload/asyncomplete/sources/flow.vim
+++ b/autoload/asyncomplete/sources/flow.vim
@@ -73,7 +73,7 @@ function! s:write_buffer_to_tempfile(ctx) abort
 
     " Insert the base and magic token into the current line.
     let l:curline = l:lines[l:lnum - 1]
-    let l:lines[l:lnum - 1] = l:curline[:l:lnum - 1] . s:autotok . l:curline[l:lnum :]
+    let l:lines[l:lnum - 1] = l:curline[:l:col - 1] . s:autotok . l:curline[l:col:]
 
     let l:file = tempname()
     call writefile(l:lines, l:file)


### PR DESCRIPTION
That was definitely a typo (used line num instead of column num) previously.